### PR TITLE
reset uart3 and add cpx example,test ok

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -140,6 +140,48 @@
 							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.symbolsrec.830040511" name="MCU Output Converter Motorola S-rec with symbols" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.symbolsrec"/>
 						</toolChain>
 					</folderInfo>
+					<fileInfo id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1263579158.1867415259" name="cpx_example.c" rcbsApplicability="disable" resourcePath="examples/cpx_example/cpx_example.c" toolsToInvoke="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.109154183.1583446311">
+						<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.109154183.1583446311" name="MCU GCC Compiler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.109154183">
+							<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths.1655182471" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths" valueType="includePath">
+								<listOptionValue builtIn="false" value="../Core/Inc"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/app-example/tinymap/inc}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Athena-Driver/Athena_deck_HAL/inc}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Athena-Driver/BSP/Components/TCA6408A/inc}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Athena-Driver/BSP/Components/VL53L5CX_ULD_API/inc}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Athena-Driver}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Athena-Driver/BSP/Components/W25Q64/inc}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Drivers/CMSIS}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Drivers/STM32L4xx_HAL_Driver}&quot;"/>
+								<listOptionValue builtIn="false" value="../Drivers/STM32L4xx_HAL_Driver/Inc"/>
+								<listOptionValue builtIn="false" value="../Middlewares/Third_Party/FreeRTOS/Source/include"/>
+								<listOptionValue builtIn="false" value="../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2"/>
+								<listOptionValue builtIn="false" value="../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F"/>
+								<listOptionValue builtIn="false" value="../Drivers/CMSIS/Device/ST/STM32L4xx/Include"/>
+								<listOptionValue builtIn="false" value="../Drivers/CMSIS/Include"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Athena-Driver/SysDriver/inc}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Athena-Driver/BSP/Components/DW3000/include}&quot;"/>
+								<listOptionValue builtIn="false" value="../AdHocUWB/Inc/"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Athena-Driver/BSP/Components/FM25CL64}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Athena-Driver/BSP/Components/FM25CL64/inc}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Athena-Driver/BSP/Components/FM25CL64/src}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Athena-Driver/SysDriver/inc/Flash_FS}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/examples/FS_example}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/examples/FS_example/inc}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/examples/FS_example/src}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/examples/tof_get_data}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/examples/DebugPrint_example}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/examples/DebugPrint_example/inc}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/examples/DebugPrint_example/src}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/examples/UWB_send_recv_packet}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/examples/UWB_send_recv_packet/inc}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/examples/UWB_send_recv_packet/src}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/examples}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/examples/init_func_example}&quot;"/>
+								<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/examples/cpx_example}&quot;"/>
+							</option>
+							<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.2101388871" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>
+						</tool>
+					</fileInfo>
 					<fileInfo id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.1263579158.2124766754" name="w25q64.h" rcbsApplicability="disable" resourcePath="Athena-Driver/BSP/Components/W25Q64/inc/w25q64.h" toolsToInvoke=""/>
 					<sourceEntries>
 						<entry excluding="BSP/Components/W25Q64/src/w25q64.c|Athena_deck_HAL/src/i2c_hal.c|BSP/Components/W25Q64/inc/w25q64.h" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="Athena-Driver"/>

--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="539028609951795184" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="285028611080097757" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="468917588319810380" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="301638512385648385" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/Athena-Driver/SysDriver/inc/cpx/cpx.h
+++ b/Athena-Driver/SysDriver/inc/cpx/cpx.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define CPX_VERSION (0b00)
+
+typedef enum
+{
+  CPX_T_STM32 = 1,
+  CPX_T_WIFI_HOST = 3,
+  CPX_T_ESP32 = 2,
+  CPX_T_GAP8 = 4,
+  CPX_T_ATHENA = 5
+} CPXTarget_t;
+
+typedef enum
+{
+    CPX_F_SYSTEM = 1,
+    CPX_F_CONSOLE = 2,
+    CPX_F_CRTP = 3,
+    CPX_F_WIFI_CTRL = 4,
+    CPX_F_APP = 5,
+    CPX_F_TEST = 0x0E,
+    CPX_F_BOOTLOADER = 0x0F,
+    CPX_F_LAST // NEEDS TO BE LAST
+} CPXFunction_t;
+
+typedef struct
+{
+    CPXTarget_t destination;
+    CPXTarget_t source;
+    bool lastPacket;
+    CPXFunction_t function;
+    uint8_t version;
+} CPXRouting_t;
+
+// This struct contains routing information in a packed format. This struct
+// should mainly be used to serialize data when tranferring. Unpacked formats
+// should be preferred in application code.
+typedef struct
+{
+    CPXTarget_t destination : 3;
+    CPXTarget_t source : 3;
+    bool lastPacket : 1;
+    bool reserved : 1;
+    CPXFunction_t function : 6;
+    uint8_t version : 2;
+} __attribute__((packed)) CPXRoutingPacked_t;
+
+#define CPX_ROUTING_PACKED_SIZE (sizeof(CPXRoutingPacked_t))
+
+#define CPX_HEADER_SIZE (2)
+
+// The maximum MTU of any link
+#define CPX_MAX_PAYLOAD_SIZE 100
+
+typedef struct
+{
+    uint16_t wireLength;
+    CPXRoutingPacked_t route;
+    uint8_t data[CPX_MAX_PAYLOAD_SIZE - CPX_HEADER_SIZE];
+} __attribute__((packed)) CPXPacketPacked_t;
+
+
+
+typedef struct
+{
+    CPXRouting_t route;
+    uint16_t dataLength;
+    uint8_t data[CPX_MAX_PAYLOAD_SIZE-CPX_HEADER_SIZE];
+} CPXPacket_t;
+
+typedef struct
+{
+  CPXRouting_t route;
+
+  uint16_t dataLength;
+  uint8_t data[CPX_MAX_PAYLOAD_SIZE - CPX_ROUTING_PACKED_SIZE];
+} CPXRoutablePacket_t;
+
+void cpxInit(void);
+
+void cpxInitRoute(const CPXTarget_t source, const CPXTarget_t destination, const CPXFunction_t function, CPXRouting_t *route);
+void cpx(void* _param);
+
+bool cpxCheckVersion(uint8_t version);
+
+typedef void (*cpxAppMessageHandlerCallback_t)(const CPXPacket_t *cpxRx);
+void cpxRegisterAppMessageHandler(cpxAppMessageHandlerCallback_t callback);
+void cpxRouteToPacked(const CPXRouting_t* route, CPXRoutingPacked_t* packed);
+void cpxPackedToRoute(const CPXRoutingPacked_t* packed, CPXRouting_t* route);
+void cpxSendPacket(const CPXRoutablePacket_t* packet);
+//void assemblePacket(const CPXPacket_t *packet, uint8_t *buffer, uint32_t *length);
+void cpxSendPacketBlocking(const CPXPacket_t *packet);

--- a/Athena-Driver/SysDriver/inc/cpx/router.h
+++ b/Athena-Driver/SysDriver/inc/cpx/router.h
@@ -1,0 +1,17 @@
+/*
+ * router.h
+ *
+ *  Created on: Dec 30, 2024
+ *      Author: 18387
+ */
+
+#ifndef SYSDRIVER_INC_CPX_ROUTER_H_
+#define SYSDRIVER_INC_CPX_ROUTER_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+void routerInit(void);
+void cpxInternalRouterReceiveOthers(CPXPacket_t * packet);
+void cpxSendPacketBlocking(const CPXPacket_t * packet);
+#endif /* SYSDRIVER_INC_CPX_ROUTER_H_ */

--- a/Athena-Driver/SysDriver/inc/cpx/uart_transport.h
+++ b/Athena-Driver/SysDriver/inc/cpx/uart_transport.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// The UART transport module represents the transport link between the router and the STM on the Crazyflie.
+
+#include <stdint.h>
+#include <stddef.h>
+#include "cpx.h"
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "semphr.h"
+#include "event_groups.h"
+#define UART_TRANSPORT_MTU 100
+
+
+
+void uart_transport_init();
+
+// Interface used by the router
+void uart_transport_send(const CPXRoutablePacket_t* packet);
+void uart_transport_receive(CPXRoutablePacket_t* packet);

--- a/Athena-Driver/SysDriver/src/cpx/cpx.c
+++ b/Athena-Driver/SysDriver/src/cpx/cpx.c
@@ -1,0 +1,112 @@
+/*
+ * cpx.c
+ *
+ *  Created on: Aug 20, 2024
+ *      Author: 18387
+ */
+
+
+#include "cpx/cpx.h"
+#include <string.h>
+#include <stdbool.h>
+#include "uart_hal.h"
+#include "cpx/uart_transport.h"
+#include "cpx/router.h"
+#include "debug.h"
+#include "cmsis_os.h"
+static cpxAppMessageHandlerCallback_t appMessageHandlerCallback = NULL;
+static CPXPacket_t cpxRxPacket;
+
+osThreadId_t cpxTaskHandle;
+
+const osThreadAttr_t cpxTask_attributes = {
+  .name = "cpxTask",
+  .stack_size = 5000,
+  .priority = (osPriority_t) osPriorityNormal,
+};
+void cpx(void* _param) {
+    while (1) {
+        // 从内部队列rxq接收数据包
+    	cpxInternalRouterReceiveOthers(&cpxRxPacket);
+        // 根据目标地址路由消息
+        switch (cpxRxPacket.route.function) {
+            case CPX_F_APP:
+                if (appMessageHandlerCallback) {
+                    appMessageHandlerCallback(&cpxRxPacket); // 调用应用层回调处理
+                }
+                break;
+
+
+            default:
+                DEBUG_PRINTF("Unhandled function: 0x%02X\n", cpxRxPacket.route.function);
+                break;
+        }
+    }
+}
+
+
+void cpxInitRoute(const CPXTarget_t source, const CPXTarget_t destination, const CPXFunction_t function, CPXRouting_t *route) {
+    route->source = source;
+    route->destination = destination;
+    route->function = function;
+    route->version = CPX_VERSION;
+    route->lastPacket = true;      // 默认设置为最后一个包
+}
+
+bool cpxCheckVersion(uint8_t version) {
+
+    return version == CPX_VERSION;
+}
+
+void cpxRegisterAppMessageHandler(cpxAppMessageHandlerCallback_t callback) {
+
+    appMessageHandlerCallback = callback;
+}
+
+
+void cpxRouteToPacked(const CPXRouting_t* route, CPXRoutingPacked_t* packed) {
+    packed->source = route->source;
+    packed->destination = route->destination;
+    packed->function = route->function;
+    packed->version = route->version;
+    packed->lastPacket = route->lastPacket;
+}
+
+void cpxPackedToRoute(const CPXRoutingPacked_t* packed, CPXRouting_t* route) {
+    if(CPX_VERSION == packed->version)
+    {
+        route->version = packed->version;
+        route->source = packed->source;
+        route->destination = packed->destination;
+        route->function = packed->function;
+        route->lastPacket = packed->lastPacket;
+    }
+}
+
+void cpxSendPacket(const CPXRoutablePacket_t* packet) {
+	uart_transport_send(packet);
+
+}
+
+//void cpxSendPacketBlocking(const CPXPacket_t *packet) {
+//    CPXPacketPacked_t txpPacked;
+//
+//    // 填充数据
+//    txpPacked.wireLength = packet->dataLength + CPX_HEADER_SIZE;
+//    txpPacked.route.destination = packet->route.destination;
+//    txpPacked.route.source = packet->route.source;
+//    txpPacked.route.function = packet->route.function;
+//    txpPacked.route.version = packet->route.version;
+//    txpPacked.route.lastPacket = packet->route.lastPacket;
+//    memcpy(txpPacked.data, packet->data, packet->dataLength);
+//
+//    // 通过 UART 发送数据
+//    UART_DMA_Transmit((uint8_t *)&txpPacked, txpPacked.wireLength);
+//}
+
+void cpxInit(void) {
+	cpxTaskHandle = osThreadNew(cpx, NULL, &cpxTask_attributes);
+
+}
+
+

--- a/Athena-Driver/SysDriver/src/cpx/router.c
+++ b/Athena-Driver/SysDriver/src/cpx/router.c
@@ -1,0 +1,174 @@
+/*
+ * router.c
+ *
+ *  Created on: Dec 30, 2024
+ *      Author: 18387
+ */
+
+
+#include "cpx/cpx.h"
+#include <string.h>
+#include <stdbool.h>
+#include "uart_hal.h"
+#include "cpx/uart_transport.h"
+#include "cpx/router.h"
+#include "cpx/cpx.h"
+#include "debug.h"
+#include "cmsis_os.h"
+
+#define QUEUE_LENGTH (2)
+osThreadId_t router_uartTaskHandle;
+const osThreadAttr_t router_uartTask_attributes = {
+  .name = "router_uartTask",
+  .stack_size = 2000,
+  .priority = (osPriority_t) osPriorityAboveNormal,
+};
+
+osThreadId_t router_internalTaskHandle;
+const osThreadAttr_t router_internalTask_attributes = {
+  .name = "router_internalTask",
+  .stack_size = 2000,
+  .priority = (osPriority_t) osPriorityAboveNormal,
+};
+
+typedef struct
+{
+  CPXRoutablePacket_t txp;
+} RouteContext_t;
+
+static RouteContext_t internal_task_context;
+static CPXRoutablePacket_t internalRxBuf;
+
+static RouteContext_t uart_task_context;
+static CPXRoutablePacket_t uartRxBuf;
+
+typedef void (*Receiver_t)(CPXRoutablePacket_t *packet);
+typedef void (*Sender_t)(const CPXRoutablePacket_t *packet);
+
+static const int START_UP_UART_ROUTER_RUNNING = (1 << 0);
+static const int START_UP_INTERNAL_ROUTER_RUNNING = (1 << 1);
+
+static EventGroupHandle_t startUpEventGroup;
+
+static xQueueHandle rxq;
+
+static xQueueHandle txq;
+
+
+
+void cpxInternalRouterReceiveOthers(CPXPacket_t * packet) {
+  xQueueReceive(rxq, packet, (TickType_t)portMAX_DELAY);
+}
+
+void cpxInternalRouterRouteIn(const CPXRoutablePacket_t* packet) {
+  // this should never fail, as it should be checked when the packet is received
+  // however, double checking doesn't harm
+  if (cpxCheckVersion(packet->route.version)) {
+        xQueueSend(rxq, packet, portMAX_DELAY);
+    }
+
+}
+
+void cpxInternalRouterRouteOut(CPXRoutablePacket_t* packet) {
+  xQueueReceive(txq, packet, (TickType_t)portMAX_DELAY);
+}
+
+static void splitAndSend(const CPXRoutablePacket_t *rxp, RouteContext_t *context, Sender_t sender, const uint16_t mtu)
+{
+  CPXRoutablePacket_t *txp = &context->txp;
+
+  txp->route = rxp->route;
+
+  uint16_t remainingToSend = rxp->dataLength;
+  const uint8_t *startOfDataToSend = rxp->data;
+  while (remainingToSend > 0)
+  {
+    uint16_t toSend = remainingToSend;
+    bool lastPacket = rxp->route.lastPacket;
+    if (toSend > mtu)
+    {
+      toSend = mtu;
+      lastPacket = false;
+    }
+
+    memcpy(txp->data, startOfDataToSend, toSend);
+    txp->dataLength = toSend;
+    txp->route.lastPacket = lastPacket;
+    sender(txp);
+
+    remainingToSend -= toSend;
+    startOfDataToSend += toSend;
+  }
+}
+
+static void route(Receiver_t receive, CPXRoutablePacket_t *rxp, RouteContext_t *context, const char *routerName)
+{
+  while (1)
+  {
+    receive(rxp);
+    // this should never fail, as it should be checked when the packet is received
+    // however, double checking doesn't harm
+    if (cpxCheckVersion(rxp->route.version))
+    {
+      const CPXTarget_t source = rxp->route.source;
+      const CPXTarget_t destination = rxp->route.destination;
+      const uint16_t cpxDataLength = rxp->dataLength;
+
+      switch (destination)
+      {
+      case CPX_T_WIFI_HOST:
+      case CPX_T_ESP32:
+
+      case CPX_T_STM32:
+        // DEBUG_PRINT("%s [0x%02X] -> UART2 [0x%02X] (%u)\n", routerName, source, destination, cpxDataLength);
+        splitAndSend(rxp, context, uart_transport_send, UART_TRANSPORT_MTU - CPX_HEADER_SIZE);
+        break;
+      case CPX_T_GAP8:
+        // DEBUG_PRINT("%s [0x%02X] -> STM32 [0x%02X] (%u)\n", routerName, source, destination, cpxDataLength);
+        splitAndSend(rxp, context, cpxInternalRouterRouteIn, UART_TRANSPORT_MTU - CPX_HEADER_SIZE);
+        break;
+      default:
+        DEBUG_PRINTF("Cannot route from %s [0x%02X] to [0x%02X](%u)\n", routerName, source, destination, cpxDataLength);
+        break;
+      }
+    }
+  }
+}
+
+static void router_from_uart(void *_param)
+{
+  xEventGroupSetBits(startUpEventGroup, START_UP_UART_ROUTER_RUNNING);
+  route(uart_transport_receive, &uartRxBuf, &uart_task_context, "UART2");
+}
+
+static void router_from_internal(void *_param)
+{
+  xEventGroupSetBits(startUpEventGroup, START_UP_INTERNAL_ROUTER_RUNNING);
+  route(cpxInternalRouterRouteOut, &internalRxBuf, &internal_task_context, "Athena");
+}
+
+void routerInit()
+{
+	txq = xQueueCreate(QUEUE_LENGTH, sizeof(CPXPacket_t));
+
+	  rxq = xQueueCreate(QUEUE_LENGTH, sizeof(CPXPacket_t));;
+  startUpEventGroup = xEventGroupCreate();
+  xEventGroupClearBits(startUpEventGroup, START_UP_UART_ROUTER_RUNNING | START_UP_INTERNAL_ROUTER_RUNNING);
+
+  router_uartTaskHandle = osThreadNew(router_from_uart, NULL, &router_uartTask_attributes);
+  //xTaskCreate(router_from_uart, CPX_RT_UART_TASK_NAME, AI_DECK_TASK_STACKSIZE, NULL, AI_DECK_TASK_PRI, NULL);
+  //xTaskCreate(router_from_internal, CPX_RT_INT_TASK_NAME, AI_DECK_TASK_STACKSIZE, NULL, AI_DECK_TASK_PRI, NULL);
+  router_internalTaskHandle = osThreadNew(router_from_internal, NULL, &router_internalTask_attributes);
+  DEBUG_PRINTF("Waiting for CPX External router initialization\n");
+  xEventGroupWaitBits(startUpEventGroup,
+                      START_UP_UART_ROUTER_RUNNING | START_UP_INTERNAL_ROUTER_RUNNING,
+                      pdTRUE, // Clear bits before returning
+                      pdTRUE, // Wait for all bits
+                      portMAX_DELAY);
+
+  DEBUG_PRINTF("CPX External router initialized, CPX_VERSION: %d\n", CPX_VERSION);
+}
+
+void cpxSendPacketBlocking(const CPXPacket_t * packet) {
+    xQueueSend(txq, packet, portMAX_DELAY);
+}

--- a/Athena-Driver/SysDriver/src/cpx/uart_transport.c
+++ b/Athena-Driver/SysDriver/src/cpx/uart_transport.c
@@ -1,0 +1,255 @@
+
+
+#include "cpx/uart_transport.h"
+
+#include <stdio.h>
+#include <string.h>
+#include "debug.h"
+#include "w25q64_ll.h"
+#include "cmsis_os.h"
+#include "uart_receive.h"
+#include "usart.h"
+// Length of start + payloadLength
+#define UART_HEADER_LENGTH 2
+#define UART_CRC_LENGTH 1
+#define UART_META_LENGTH (UART_HEADER_LENGTH + UART_CRC_LENGTH)
+
+typedef struct {
+    CPXRoutingPacked_t route;
+    uint8_t data[UART_TRANSPORT_MTU - CPX_ROUTING_PACKED_SIZE];
+} __attribute__((packed)) uartTransportPayload_t;
+
+typedef struct {
+    uint8_t start;
+    uint8_t payloadLength; // Excluding start and crc
+    union {
+        uartTransportPayload_t routablePayload;
+        uint8_t payload[UART_TRANSPORT_MTU];
+    };
+
+    uint8_t crcPlaceHolder; // Not actual position. CRC is added after the last byte of payload
+} __attribute__((packed)) uart_transport_packet_t;
+
+
+
+#define TX_QUEUE_LENGTH 10
+#define RX_QUEUE_LENGTH 10
+
+static xQueueHandle tx_queue;
+static xQueueHandle rx_queue;
+
+static CPXRoutablePacket_t qPacket;
+static uart_transport_packet_t txp;
+static uart_transport_packet_t rxp;
+
+static EventGroupHandle_t evGroup;
+static EventGroupHandle_t startUpEventGroup;
+
+osThreadId_t rxTaskHandle;
+const osThreadAttr_t rxTask_attributes = {
+  .name = "rxTask",
+  .stack_size = 2000,
+  .priority = (osPriority_t) osPriorityAboveNormal,
+};
+osThreadId_t txTaskHandle;
+const osThreadAttr_t txTask_attributes = {
+  .name = "txTask",
+  .stack_size = 2000,
+  .priority = (osPriority_t) osPriorityNormal,
+};
+#define CTS_EVENT (1<<0)
+#define CTR_EVENT (1<<1)
+#define TXQ_EVENT (1<<2)
+
+#define START_UP_RX_RUNNING (1<<0)
+#define START_UP_TX_RUNNING (1<<1)
+
+static uint8_t calcCrc(const uart_transport_packet_t* packet) {
+  const uint8_t* start = (const uint8_t*) packet;
+  const uint8_t* end = &packet->payload[packet->payloadLength];
+
+  uint8_t crc = 0;
+  for (const uint8_t* p = start; p < end; p++) {
+    crc ^= *p;
+  }
+
+  return crc;
+}
+
+
+
+
+static void uart_tx_task(void* _param) {
+  uint8_t ctr[] = {0xFF, 0x00};
+  EventBits_t evBits = 0;
+  //LL_GPIO_TogglePin(GPIOB, LL_GPIO_PIN_9);
+  // Note: RX task must be running before we start the TX task
+  xEventGroupSetBits(startUpEventGroup, START_UP_TX_RUNNING);
+
+  do {
+	  //UART_DMA_Transmit(ctr, sizeof(ctr));
+	  Uart3_SendStr((char*)ctr, sizeof(ctr));
+	  //LL_GPIO_TogglePin(GPIOB, LL_GPIO_PIN_9);
+	  vTaskDelay(pdMS_TO_TICKS(100));
+	  evBits = xEventGroupGetBits(evGroup);
+  } while ((evBits & CTS_EVENT) != CTS_EVENT);
+  //LL_GPIO_TogglePin(GPIOB, LL_GPIO_PIN_9);
+
+  while(1) {
+    // If we have nothing to send then wait, either for something to be
+    // queued or for a request to send CTR
+    if (uxQueueMessagesWaiting(tx_queue) == 0) {
+    	//DEBUG_PRINTF("waiting for ctr/txq");
+    	evBits = xEventGroupWaitBits(evGroup,
+                                CTR_EVENT | TXQ_EVENT,
+                                pdTRUE, // Clear bits before returning
+                                pdFALSE, // Wait for any bit
+                                portMAX_DELAY);
+      if ((evBits & CTR_EVENT) == CTR_EVENT) {
+    	  //DEBUG_PRINTF("send ctr\n");
+    	  //UART_DMA_Transmit(ctr, sizeof(ctr));
+    	  Uart3_SendStr((char*)ctr, sizeof(ctr));
+    	  //LL_GPIO_TogglePin(GPIOB, LL_GPIO_PIN_9);
+      }
+    }
+
+    if (uxQueueMessagesWaiting(tx_queue) > 0) {
+      // Dequeue and wait for either CTS or CTR
+      //LL_GPIO_TogglePin(GPIOB, LL_GPIO_PIN_9);
+      xQueueReceive(tx_queue, &qPacket, 0);
+      txp.start = 0xFF;
+      txp.payloadLength = qPacket.dataLength + CPX_ROUTING_PACKED_SIZE;
+      cpxRouteToPacked(&qPacket.route, &txp.routablePayload.route);
+      memcpy(txp.routablePayload.data, qPacket.data, txp.payloadLength);
+      txp.payload[txp.payloadLength] = calcCrc(&txp);
+      //LL_GPIO_TogglePin(GPIOB, LL_GPIO_PIN_9);
+      do {
+    	//DEBUG_PRINTF("waingting for ctr/cts\n");
+        evBits = xEventGroupWaitBits(evGroup,
+                                CTR_EVENT | CTS_EVENT,
+                                pdTRUE, // Clear bits before returning
+                                pdFALSE, // Wait for any bit
+                                portMAX_DELAY);
+        if ((evBits & CTR_EVENT) == CTR_EVENT) {
+        	//DEBUG_PRINTF("send ctr\n");
+        	//UART_DMA_Transmit(ctr, sizeof(ctr));
+        	Uart3_SendStr((char*)ctr, sizeof(ctr));
+        }
+      } while ((evBits & CTS_EVENT) != CTS_EVENT);
+      //DEBUG_PRINTF("send packet\n");
+      //UART_DMA_Transmit((uint8_t *)&txp, txp.payloadLength + UART_META_LENGTH);
+      Uart3_SendStr((char*)&txp, txp.payloadLength + UART_META_LENGTH);
+      //LL_GPIO_TogglePin(GPIOB, LL_GPIO_PIN_9);
+    }
+  }
+}
+
+
+static void uart_rx_task(void* _param) {
+  xEventGroupSetBits(startUpEventGroup, START_UP_RX_RUNNING);
+
+  while(1) {
+    do {
+    	xQueueReceive(UartRxQueue, &rxp.start, portMAX_DELAY);
+    	//DEBUG_PRINTF("%u\n",rxp.start);
+    	//LL_GPIO_TogglePin(GPIOB, LL_GPIO_PIN_9);
+    	vTaskDelay(pdMS_TO_TICKS(10));
+    } while (rxp.start != 0xFF);
+    xQueueReceive(UartRxQueue, &rxp.payloadLength, portMAX_DELAY);
+    //DEBUG_PRINTF("%u\n",rxp.payloadLength);
+    LL_GPIO_TogglePin(GPIOB, LL_GPIO_PIN_9);
+    if (rxp.payloadLength == 0) {
+    	//DEBUG_PRINTF("received cts\n");
+      xEventGroupSetBits(evGroup, CTS_EVENT);
+      //LL_GPIO_TogglePin(GPIOB, LL_GPIO_PIN_9);
+    } else {
+    	for (int i = 0; i < rxp.payloadLength + UART_CRC_LENGTH; i++) {
+    	                xQueueReceive(UartRxQueue, &rxp.payload[i], portMAX_DELAY);
+    	            }
+      assert (rxp.payload[rxp.payloadLength] == calcCrc(&rxp));
+      //DEBUG_PRINTF("received ======\n a packet\n");
+      // Post on RX queue and send flow control
+      // Optimize a bit here
+      if (uxQueueSpacesAvailable(rx_queue) > 0) {
+        xEventGroupSetBits(evGroup, CTR_EVENT);
+        xQueueSend(rx_queue, &rxp, portMAX_DELAY);
+      } else {
+        xQueueSend(rx_queue, &rxp, portMAX_DELAY);
+        xEventGroupSetBits(evGroup, CTR_EVENT);
+      }
+    }
+  }
+
+}
+
+void uart_transport_init() {
+	DEBUG_PRINTF("this is a init test: \n");
+    // Setting up synchronization items
+    tx_queue = xQueueCreate(TX_QUEUE_LENGTH, sizeof(CPXRoutablePacket_t));
+    rx_queue = xQueueCreate(RX_QUEUE_LENGTH, sizeof(uart_transport_packet_t));
+
+    evGroup = xEventGroupCreate();
+
+//    const uart_config_t uart_config = {
+//        .baud_rate = 576000,
+//        .data_bits = UART_DATA_8_BITS,
+//        .parity = UART_PARITY_DISABLE,
+//        .stop_bits = UART_STOP_BITS_1,
+//        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+//        //.source_clk = UART_SCLK_APB,
+//    };
+//    // We won't use a buffer for sending data.
+//    uart_driver_install(UART_NUM_0, UART_TRANSPORT_MTU * 2, UART_TRANSPORT_MTU * 2, 0, NULL, 0);
+//    uart_param_config(UART_NUM_0, &uart_config);
+//    uart_set_pin(UART_NUM_0, TXD_PIN, RXD_PIN, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+
+    // Launching communication tasks
+    startUpEventGroup = xEventGroupCreate();
+    xEventGroupClearBits(startUpEventGroup, START_UP_RX_RUNNING | START_UP_TX_RUNNING);
+    //xTaskCreate(uart_rx_task, "UART RX transport", 5000, NULL, 1, NULL);
+    rxTaskHandle = osThreadNew(uart_rx_task, NULL, &rxTask_attributes);
+    //DEBUG_PRINTF("waiting for rx to start\n");
+    xEventGroupWaitBits(startUpEventGroup,
+                        START_UP_RX_RUNNING,
+                        pdTRUE, // Clear bits before returning
+                        pdTRUE, // Wait for all bits
+                        portMAX_DELAY);
+
+    // We need to hold off here to make sure that the RX task
+    // has started up and is waiting for chars before he TX task is started, otherwise we might send
+    // CTR and miss CTS (which means that the STM32 will stop sending CTS
+    // too early and we cannot sync)
+    osDelay(pdMS_TO_TICKS(100));
+    //xTaskCreate(uart_tx_task, "UART TX transport", 5000, NULL, 1, NULL);
+    txTaskHandle = osThreadNew(uart_tx_task, NULL, &txTask_attributes);
+    //DEBUG_PRINTF("waiting for tx to start\n");
+    xEventGroupWaitBits(startUpEventGroup,
+                        START_UP_TX_RUNNING,
+                        pdTRUE, // Clear bits before returning
+                        pdTRUE, // Wait for all bits
+                        portMAX_DELAY);
+    //DEBUG_PRINTF("transport initialized\n");
+}
+
+void uart_transport_send(const CPXRoutablePacket_t* packet) {
+  assert(packet->dataLength <= UART_TRANSPORT_MTU - CPX_ROUTING_PACKED_SIZE);
+
+  xQueueSend(tx_queue, packet, portMAX_DELAY);
+  //DEBUG_PRINTF("send to uart txq\n");
+  xEventGroupSetBits(evGroup, TXQ_EVENT);
+  //LL_GPIO_TogglePin(GPIOB, LL_GPIO_PIN_9);
+}
+
+void uart_transport_receive(CPXRoutablePacket_t* packet) {
+  // Not reentrant safe. Assume only one task dequeues packets
+  static uart_transport_packet_t rxp;
+
+  xQueueReceive(rx_queue, &rxp, portMAX_DELAY);
+
+  packet->dataLength = rxp.payloadLength - CPX_ROUTING_PACKED_SIZE;
+
+  cpxPackedToRoute(&rxp.routablePayload.route, &packet->route);
+
+  memcpy(packet->data, rxp.routablePayload.data, packet->dataLength);
+  //LL_GPIO_TogglePin(GPIOB, LL_GPIO_PIN_9);
+}

--- a/Core/Inc/usart.h
+++ b/Core/Inc/usart.h
@@ -35,7 +35,7 @@ extern "C" {
 
 /* USER CODE BEGIN Private defines */
 void uart3SendData(uint32_t size, uint8_t* data);
-void Uart3_SendStr(char*SendBuf);
+void Uart3_SendStr(char* SendBuf, uint8_t size);
 /* USER CODE END Private defines */
 
 void MX_USART1_UART_Init(void);

--- a/Core/Src/freertos.c
+++ b/Core/Src/freertos.c
@@ -45,6 +45,10 @@
 
 #include "../../examples/FS_example/src/Flash_FS_Example.c"
 #include "uwb_send_recv_packet_example.c"
+#include "cpx/cpx.h"
+#include "cpx/uart_transport.h"
+#include "cpx/router.h"
+#include "../../examples/cpx_example/cpx_example.c"
 //#include "adhocuwb.h"
 
 /* USER CODE END Includes */
@@ -117,6 +121,12 @@ const osThreadAttr_t uwb_send_recv_packet_Example_attributes = {
 		.stack_size = 2 * UWB_FRAME_LEN_MAX * sizeof(StackType_t),
 		.priority = (osPriority_t) osPriorityNormal,
 };
+osThreadId_t cpx_ExampleHandle;
+const osThreadAttr_t cpx_Example_attributes = {
+		.name = "cpx_Example",
+		.stack_size = 128 * 2,
+		.priority = (osPriority_t) osPriorityNormal,
+};
 /* Private function prototypes -----------------------------------------------*/
 /* USER CODE BEGIN FunctionPrototypes */
 
@@ -132,7 +142,7 @@ void MX_FREERTOS_Init(void) {
 	rxComplete = xSemaphoreCreateBinary();
 	spiMutex = xSemaphoreCreateMutex();
 	UartRxReady = xSemaphoreCreateBinary();
-//	CreateUartRxQueue();
+	CreateUartRxQueue();
 	if (txComplete == NULL || rxComplete == NULL || spiMutex == NULL)
 	{
 	    while (1);
@@ -144,7 +154,7 @@ void MX_FREERTOS_Init(void) {
 //	FS_ExampleHandle = osThreadNew(FS_Example, NULL, &FS_Example_attributes);
 //  ledTaskHandle = osThreadNew(ledTask, NULL, &ledTask_attributes);
 	// uwb_send_recv_packet_ExampleHandle = osThreadNew(uwbSendRecvPacketTask, NULL, &uwb_send_recv_packet_Example_attributes);
-
+	cpx_ExampleHandle = osThreadNew(cpx_Example, NULL, &cpx_Example_attributes);
 	initConfig = &_userInit_start;
 	while(initConfig < &_userInit_stop){
 	   (*initConfig)->init();

--- a/Core/Src/freertos.c
+++ b/Core/Src/freertos.c
@@ -121,12 +121,7 @@ const osThreadAttr_t uwb_send_recv_packet_Example_attributes = {
 		.stack_size = 2 * UWB_FRAME_LEN_MAX * sizeof(StackType_t),
 		.priority = (osPriority_t) osPriorityNormal,
 };
-osThreadId_t cpx_ExampleHandle;
-const osThreadAttr_t cpx_Example_attributes = {
-		.name = "cpx_Example",
-		.stack_size = 128 * 2,
-		.priority = (osPriority_t) osPriorityNormal,
-};
+
 /* Private function prototypes -----------------------------------------------*/
 /* USER CODE BEGIN FunctionPrototypes */
 
@@ -154,7 +149,7 @@ void MX_FREERTOS_Init(void) {
 //	FS_ExampleHandle = osThreadNew(FS_Example, NULL, &FS_Example_attributes);
 //  ledTaskHandle = osThreadNew(ledTask, NULL, &ledTask_attributes);
 	// uwb_send_recv_packet_ExampleHandle = osThreadNew(uwbSendRecvPacketTask, NULL, &uwb_send_recv_packet_Example_attributes);
-	cpx_ExampleHandle = osThreadNew(cpx_Example, NULL, &cpx_Example_attributes);
+
 	initConfig = &_userInit_start;
 	while(initConfig < &_userInit_stop){
 	   (*initConfig)->init();

--- a/Core/Src/usart.c
+++ b/Core/Src/usart.c
@@ -186,10 +186,10 @@ void MX_USART3_UART_Init(void)
 
 //  /* USER CODE BEGIN USART3_Init 1 */
 //  LL_DMA_EnableIT_TC(DMA1, LL_DMA_CHANNEL_3);
-//  LL_USART_EnableIT_RXNE(USART3); // 使能接收缓冲区非空中�?
+  LL_USART_EnableIT_RXNE(USART3); // 使能接收缓冲区非空中�?
 
   /* USER CODE END USART3_Init 1 */
-  USART_InitStruct.BaudRate = 115200;
+  USART_InitStruct.BaudRate = 576000;
   USART_InitStruct.DataWidth = LL_USART_DATAWIDTH_8B;
   USART_InitStruct.StopBits = LL_USART_STOPBITS_1;
   USART_InitStruct.Parity = LL_USART_PARITY_NONE;
@@ -206,14 +206,13 @@ void MX_USART3_UART_Init(void)
 }
 
 /* USER CODE BEGIN 1 */
-void Uart3_SendStr(char*SendBuf)//串口1发送字符串
-{
-  while(*SendBuf)
-  {
-    while(LL_USART_IsActiveFlag_TC(USART3)!=1);//等待发送完成
-    LL_USART_TransmitData8(USART3,(uint8_t)(*SendBuf & (uint8_t)0xff));//发送数据
-    SendBuf++;
-  }
+void Uart3_SendStr(char* SendBuf, uint8_t size) {
+    while (size > 0) {
+        while (!LL_USART_IsActiveFlag_TC(USART3));  // 等待发送完成
+        LL_USART_TransmitData8(USART3,(uint8_t)(*SendBuf & (uint8_t)0xff));  // 发送当前字节
+        SendBuf++;
+        size--;
+    }
 }
 
 /* USER CODE END 1 */

--- a/examples/cpx_example/cpx_example.c
+++ b/examples/cpx_example/cpx_example.c
@@ -11,12 +11,17 @@ static CPXPacket_t cpxPacket;
 
 static void cpxPacketCallback(const CPXPacket_t *cpxRx)
 {
-  DEBUG_PRINTF("Got packet from cf (%u)\n", cpxRx->data[0]);
+	DEBUG_PRINTF("Got Data from STM32: [");
+	        for (size_t i = 0; i < cpxRx->dataLength; i++)
+	        {
+	            DEBUG_PRINTF("%d%s", cpxRx->data[i], (i < cpxRx->dataLength - 1) ? ", " : "");
+	        }
+	        DEBUG_PRINTF("]\n");
 }
 
 static void cpx_Example(void *argument)
 {
-	DEBUG_PRINTF("led task is up\n");
+	DEBUG_PRINTF("cpx task is up\n");
 	cpxRegisterAppMessageHandler(cpxPacketCallback);
 	DEBUG_PRINTF("to call uart_transport_init\n");
 	uart_transport_init();

--- a/examples/cpx_example/cpx_example.c
+++ b/examples/cpx_example/cpx_example.c
@@ -1,0 +1,37 @@
+#include "FreeRTOS.h"
+#include "task.h"
+#include "main.h"
+#include "cmsis_os.h"
+
+#include "cpx/cpx.h"
+#include "cpx/uart_transport.h"
+#include "cpx/router.h"
+
+static CPXPacket_t cpxPacket;
+
+static void cpxPacketCallback(const CPXPacket_t *cpxRx)
+{
+  DEBUG_PRINTF("Got packet from cf (%u)\n", cpxRx->data[0]);
+}
+
+static void cpx_Example(void *argument)
+{
+	DEBUG_PRINTF("led task is up\n");
+	cpxRegisterAppMessageHandler(cpxPacketCallback);
+	DEBUG_PRINTF("to call uart_transport_init\n");
+	uart_transport_init();
+	routerInit();
+	DEBUG_PRINTF("router initialized\n");
+	cpxInit();
+	uint8_t count=0;
+  while(1)
+  {
+	    vTaskDelay(2000);
+	    cpxInitRoute(CPX_T_GAP8, CPX_T_STM32, CPX_F_APP, &cpxPacket.route);
+	    cpxPacket.dataLength = 1;
+	    cpxPacket.data[0]=count;
+	    count++;
+	    cpxSendPacketBlocking(&cpxPacket);
+	    DEBUG_PRINTF("send packet to cf(%u).\n",cpxPacket.data[0]);
+  }
+}

--- a/examples/cpx_example/cpx_example.c
+++ b/examples/cpx_example/cpx_example.c
@@ -7,6 +7,13 @@
 #include "cpx/uart_transport.h"
 #include "cpx/router.h"
 
+osThreadId_t cpx_ExampleHandle;
+const osThreadAttr_t cpx_Example_attributes = {
+		.name = "cpx_Example",
+		.stack_size = 128 * 2,
+		.priority = (osPriority_t) osPriorityNormal,
+};
+
 static CPXPacket_t cpxPacket;
 
 static void cpxPacketCallback(const CPXPacket_t *cpxRx)
@@ -40,3 +47,13 @@ static void cpx_Example(void *argument)
 	    DEBUG_PRINTF("send packet to cf(%u).\n",cpxPacket.data[0]);
   }
 }
+void cpx_example_init(){
+	cpx_ExampleHandle = osThreadNew(cpx_Example, NULL, &cpx_Example_attributes);
+}
+
+
+static const UserInit cpx_init = {
+		.init = cpx_example_init,
+};
+
+USER_INIT(cpx_init);


### PR DESCRIPTION
重新打开了Athena上的uart3，并修改波特率为576000，与无人机端保持一致；修改了Uart3_SendStr接口，新增size参数，使其能固定长度发送字符串；在此基础上调通了已有的cpx代码，增加了cpx通信样例，双向通信测试通过
![微信截图_20250113212323](https://github.com/user-attachments/assets/7c6f7c2b-0e4c-4c8d-aa52-80df07022cff)
